### PR TITLE
speeding up bottom depth retrieval

### DIFF
--- a/scripts/toktlogger_json_to_df.py
+++ b/scripts/toktlogger_json_to_df.py
@@ -123,15 +123,11 @@ def json_to_df(toktlogger):
                     
                 elif key in ['bottomDepthInMeters']:
                     
-                    # Retrieving start time and end time of activity so it can be used to pull bottom depth between these times
+                    # Taking bottom depth for 2 seconds from start time of activity
+                    # Previously took as medium between start and end time, but was taking too long for long activities.
 
                     start_dt = dt.strptime(activity['startTime'], '%Y-%m-%dT%H:%M:%S.%fZ')
-                    end_dt = dt.strptime(activity['endTime'], '%Y-%m-%dT%H:%M:%S.%fZ')
-                    timediff = end_dt - start_dt
-                    
-                    # Start time and end time are sometimes the same so need to make them different to pull data.
-                    if (timediff).seconds < 2:
-                        start_dt = end_dt - datetime.timedelta(seconds=2)
+                    end_dt = start_dt + datetime.timedelta(seconds=2) 
                     
                     start_date = start_dt.strftime('%Y-%m-%d')
                     sthh = "{:02d}".format(start_dt.hour)


### PR DESCRIPTION
I retrieve the bottom depth by pulling data from the toktlogger. Previously, I was taking the median value between the start and end time of activities. However, this was taking a long time for long activities (e.g. ice stations or where water is deep).

To speed this up, I now take the median of only 2 seconds of data, starting at the activity start time. Coordinates are taken at the start time, so this is consistent. 