### PR TITLE
Removed DwC setup which is outdated

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -33,46 +33,46 @@ cores:
           sample_responsible: [ pi_address ]
           comments: [occurrenceRemarks, fieldNotes ]
           experiment: [incubationTemperatureInCelsius]
-  - name: darwin
-    sheets:
-      - name: darwin
-        required: [ occurrenceID, basisOfRecord, eventDate, scientificName ]
-        recommended: [ occurrenceID, basisOfRecord, eventDate, kingdom, scientificName, taxonRank, decimalLatitude, decimalLongitude, geodeticDatum, coordinateUncertaintyInMeters, countryCode, individualCount, organismQuantity, organismQuantityType ]
-        grouping: [ recordLevel, occurrence, event, location, identification, taxon, organism, other]
-        terms:
-          event: [eventID, parentEventID, fieldNumber, eventDate, eventTime, startDayOfYear,
-            endDayOfYear, year, month, day, verbatimEventDate, habitat, samplingProtocol,
-            sampleSizeValue, sampleSizeUnit, samplingEffort, fieldNotes, eventRemarks]
-          identification: [identificationID, identificationQualifier, typeStatus, identifiedBy,
-            dateIdentified, identificationReferences, identificationVerificationStatus, identificationRemarks]
-          location: [locationID, higherGeographyID, higherGeography, continent, waterBody,
-            islandGroup, island, country, countryCode, stateProvince, county, municipality,
-            locality, verbatimLocality, minimumElevationInMeters, maximumElevationInMeters,
-            verbatimElevation, minimumDepthInMeters, maximumDepthInMeters, verbatimDepth,
-            minimumDistanceAboveSurfaceInMeters, maximumDistanceAboveSurfaceInMeters, locationAccordingTo,
-            locationRemarks, decimalLatitude, decimalLongitude, geodeticDatum, coordinateUncertaintyInMeters,
-            coordinatePrecision, pointRadiusSpatialFit, verbatimCoordinates, verbatimLatitude,
-            verbatimLongitude, verbatimCoordinateSystem, verbatimSRS, footprintWKT, footprintSRS,
-            footprintSpatialFit, georeferencedBy, georeferencedDate, georeferenceProtocol,
-            georeferenceSources, georeferenceVerificationStatus, georeferenceRemarks]
-          occurrence: [occurrenceID, catalogNumber, recordNumber, recordedBy, individualCount,
-            organismQuantity, organismQuantityType, sex, lifeStage, reproductiveCondition,
-            behavior, establishmentMeans, occurrenceStatus, preparations, disposition, associatedMedia,
-            associatedReferences, associatedSequences, associatedTaxa, otherCatalogNumbers,
-            occurrenceRemarks]
-          organism: [organismID, organismName, organismScope, associatedOccurrences, associatedOrganisms,
-            previousIdentifications, organismRemarks]
-          other: [materialSampleID]
-          recordLevel: [type, modified, language, license, rightsHolder, accessRights, bibliographicCitation,
-            references, institutionID, collectionID, datasetID, institutionCode, collectionCode,
-            datasetName, ownerInstitutionCode, basisOfRecord, informationWithheld, dataGeneralizations,
-            dynamicProperties]
-          taxon: [taxonID, scientificNameID, acceptedNameUsageID, parentNameUsageID, originalNameUsageID,
-            nameAccordingToID, namePublishedInID, taxonConceptID, scientificName, acceptedNameUsage,
-            parentNameUsage, originalNameUsage, nameAccordingTo, namePublishedIn, namePublishedInYear,
-            higherClassification, kingdom, phylum, class, order, family, genus, subgenus,
-            specificEpithet, infraspecificEpithet, taxonRank, verbatimTaxonRank, scientificNameAuthorship,
-            vernacularName, nomenclaturalCode, taxonomicStatus, nomenclaturalStatus, taxonRemarks]
+#  - name: darwin
+#    sheets:
+#      - name: darwin
+#        required: [ occurrenceID, basisOfRecord, eventDate, scientificName ]
+#        recommended: [ occurrenceID, basisOfRecord, eventDate, kingdom, scientificName, taxonRank, decimalLatitude, decimalLongitude, geodeticDatum, coordinateUncertaintyInMeters, countryCode, individualCount, organismQuantity, organismQuantityType ]
+#        grouping: [ recordLevel, occurrence, event, location, identification, taxon, organism, other]
+#        terms:
+#          event: [eventID, parentEventID, fieldNumber, eventDate, eventTime, startDayOfYear,
+#            endDayOfYear, year, month, day, verbatimEventDate, habitat, samplingProtocol,
+#            sampleSizeValue, sampleSizeUnit, samplingEffort, fieldNotes, eventRemarks]
+#          identification: [identificationID, identificationQualifier, typeStatus, identifiedBy,
+#            dateIdentified, identificationReferences, identificationVerificationStatus, identificationRemarks]
+#          location: [locationID, higherGeographyID, higherGeography, continent, waterBody,
+#            islandGroup, island, country, countryCode, stateProvince, county, municipality,
+#            locality, verbatimLocality, minimumElevationInMeters, maximumElevationInMeters,
+#            verbatimElevation, minimumDepthInMeters, maximumDepthInMeters, verbatimDepth,
+#            minimumDistanceAboveSurfaceInMeters, maximumDistanceAboveSurfaceInMeters, locationAccordingTo,
+#            locationRemarks, decimalLatitude, decimalLongitude, geodeticDatum, coordinateUncertaintyInMeters,
+#            coordinatePrecision, pointRadiusSpatialFit, verbatimCoordinates, verbatimLatitude,
+#            verbatimLongitude, verbatimCoordinateSystem, verbatimSRS, footprintWKT, footprintSRS,
+#            footprintSpatialFit, georeferencedBy, georeferencedDate, georeferenceProtocol,
+#            georeferenceSources, georeferenceVerificationStatus, georeferenceRemarks]
+#          occurrence: [occurrenceID, catalogNumber, recordNumber, recordedBy, individualCount,
+#            organismQuantity, organismQuantityType, sex, lifeStage, reproductiveCondition,
+#            behavior, establishmentMeans, occurrenceStatus, preparations, disposition, associatedMedia,
+#            associatedReferences, associatedSequences, associatedTaxa, otherCatalogNumbers,
+#            occurrenceRemarks]
+#          organism: [organismID, organismName, organismScope, associatedOccurrences, associatedOrganisms,
+#            previousIdentifications, organismRemarks]
+#          other: [materialSampleID]
+#          recordLevel: [type, modified, language, license, rightsHolder, accessRights, bibliographicCitation,
+#            references, institutionID, collectionID, datasetID, institutionCode, collectionCode,
+#            datasetName, ownerInstitutionCode, basisOfRecord, informationWithheld, dataGeneralizations,
+#            dynamicProperties]
+#          taxon: [taxonID, scientificNameID, acceptedNameUsageID, parentNameUsageID, originalNameUsageID,
+#            nameAccordingToID, namePublishedInID, taxonConceptID, scientificName, acceptedNameUsage,
+#            parentNameUsage, originalNameUsage, nameAccordingTo, namePublishedIn, namePublishedInYear,
+#            higherClassification, kingdom, phylum, class, order, family, genus, subgenus,
+#            specificEpithet, infraspecificEpithet, taxonRank, verbatimTaxonRank, scientificNameAuthorship,
+#            vernacularName, nomenclaturalCode, taxonomicStatus, nomenclaturalStatus, taxonRemarks]
   - name: big
     sheets:
       - name: big

--- a/index.cgi
+++ b/index.cgi
@@ -7,7 +7,7 @@
  Fork of https://github.com/umeldt/darwinsheet
 
 
-@author:     Pål Ellingsen
+@author:     Pål Ellingsen, Luke Marsden
 @author:     Christian Svindseth
 @deffield    updated: Updated
 '''
@@ -30,11 +30,11 @@ import scripts.make_xlsx as mx
 from scripts.process_xlsx import Term
 import config.fields as fields
 
-__updated__ = '2019-05-03'
+__updated__ = '2021-11-09'
 
 
 #cgitb.enable()
-SETUP_DEFAULT = 'darwin'
+SETUP_DEFAULT = 'aen'
 
 cookie = Cookie.SimpleCookie(os.environ.get("HTTP_COOKIE"))
 


### PR DESCRIPTION
The Darwin Core setup is outdated. Also the GBIF templates are now available for logging Darwin Core data. Therefore, this setup is not redundant and should not be used.