### PR TITLE
yaml safe load

### DIFF
--- a/index.cgi
+++ b/index.cgi
@@ -55,7 +55,7 @@ else:
 # print(setup)
 
 
-cores = yaml.full_load(
+cores = yaml.safe_load(
     open(os.path.join("config", "config.yaml"), encoding='utf-8'))['cores']
 
 names = []  # For holding a list over the possible setups
@@ -66,7 +66,7 @@ for core in cores:
 
 
 # Put the language in an ordered place
-config['languages'] = yaml.full_load(
+config['languages'] = yaml.safe_load(
     open(os.path.join("config", "config.yaml"), encoding='utf-8'))['languages']
 
 if 'site_language' in cookie:


### PR DESCRIPTION
yaml.full_load does not work on earlier versions of yaml, such as 3.1.2 that SIOS are running. Changing to yaml.safe_load.